### PR TITLE
Switch to v2 of keepalive workflow to hopefully work with branch rules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,5 +85,5 @@ jobs:
 
     # keepalive-workflow adds a dummy commit if there's no other action here, keeps
     # GitHub from turning off tests after 60 days
-    - uses: gautamkrishnar/keepalive-workflow@v1
+    - uses: gautamkrishnar/keepalive-workflow@3eb47f21355191080dca0f7662d45c192d2ef64d # v2
       if: matrix.ddev_version == 'stable'


### PR DESCRIPTION
We turned on branch protection rules which is breaking things at https://github.com/Lullabot/ddev-playwright/actions/runs/10860980806.

We may have to wait 45 days for this to test.