### PR TITLE
remove Dockerfile.playwright when uninstalling

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -15,3 +15,6 @@ project_files:
   - web-build/kasmvnc.yaml
   - web-build/xstartup
   - config.playwright.yml
+
+removal_actions:
+- if grep "#ddev-generated" web-build/Dockerfile.playwright 2>/dev/null; then rm web-build/Dockerfile.playwright; fi


### PR DESCRIPTION
## Issue

After removing addon, I recieved an error after restarting the project.

```
#18 [web stage-0 15/20] COPY kasmvnc.yaml xstartup /home/user13/.vnc
#18 ERROR: failed to calculate checksum of ref 61f21c33-53c7-4dea-9576-f8b7776e5893::ut65g2k0yzbl2jvyfwuxlkf11: "/xstartup": not found

#19 [web stage-0  7/20] RUN apt-get update
#19 CANCELED
```


## Cause

When running `ddev addon remove lullabot/ddev-playwright`, DDEV's `removal_actions` removes the files listed under `project_files`.

However, during installtion the `web-build/disabled.Dockerfile.playwright` file gets copied to `web-build/Dockerfile.playwright`. This results in an orphaned file.


## Solution

This PR automates the removal of `Dockerfile.playwright`.
This prevents subsequent `ddev start` commands from failing.

This PR first checks that the file is "owned" by DDEV (ie. not customized) before deleting.

