### PR TITLE
correct addon name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Highlights include:
 ## Getting started
 
 ```console
-ddev get deviantintegral/ddev-playwright
+ddev get Lullabot/ddev-playwright
 git add .
 git add -f .ddev/config.playwright.yml
 mkdir -p test/playwright


### PR DESCRIPTION
`ddev add-on list --all` has two results with "playwright" in the name:

```
┌───────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
│ ADD-ON                                            │ DESCRIPTION                                        │
├───────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ julienloizelet/ddev-playwright                    │ Playwright add-on for ddev                         │
├───────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ Lullabot/ddev-playwright                          │ Integrate Playwright tests into your ddev app      │
└───────────────────────────────────────────────────┴────────────────────────────────────────────────────┘
```

We should update the readme to match the listing in the CLI