### PR TITLE
feat: support configurable PLAYWRIGHT_TEST_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ The full setup workflow is:
 > version in `test/playwright/package.json` so the matching browser binaries are
 > installed.
 
+> **Tip:** Tests live in `test/playwright` by default. To use a different
+> path (e.g. `tests/playwright`), add it to `.ddev/.env`:
+> ```
+> PLAYWRIGHT_TEST_DIR=tests/playwright
+> ```
+> then `ddev restart` before initializing Playwright. Substitute your
+> chosen path for `test/playwright` in the commands below.
+
 ```console
 # 1. Install the addon.
 ddev add-on get Lullabot/ddev-playwright

--- a/commands/host/install-playwright
+++ b/commands/host/install-playwright
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 #ddev-generated
 
+# Host commands don't run with the project root as cwd — DDEV runs them from
+# wherever `ddev` was invoked, which is why it exposes $DDEV_APPROOT at all.
+# Every path below (.ddev/.env, $PLAYWRIGHT_TEST_DIR, .ddev/web-build/...) is
+# relative, so anchor to the project root first or a run from a subdirectory
+# fails with a confusing "no such file" instead of doing the right thing.
+cd "$DDEV_APPROOT"
+
 # Allow overriding the test directory location via .ddev/.env, e.g.:
 #   PLAYWRIGHT_TEST_DIR=tests/playwright
 set -a

--- a/commands/host/install-playwright
+++ b/commands/host/install-playwright
@@ -6,7 +6,7 @@
 # Every path below (.ddev/.env, $PLAYWRIGHT_TEST_DIR, .ddev/web-build/...) is
 # relative, so anchor to the project root first or a run from a subdirectory
 # fails with a confusing "no such file" instead of doing the right thing.
-cd "$DDEV_APPROOT"
+cd "$DDEV_APPROOT" || exit 1
 
 # Allow overriding the test directory location via .ddev/.env, e.g.:
 #   PLAYWRIGHT_TEST_DIR=tests/playwright
@@ -51,5 +51,5 @@ fi
 # ddev errors out on subsequent builds if we symlink these files. Instead, we
 # copy them each time.
 echo "Rebuilding web service with playwright dependencies..."
-cp .ddev/web-build/disabled.Dockerfile.playwright .ddev/web-build/Dockerfile.playwright
+cp .ddev/web-build/disabled.Dockerfile.playwright .ddev/web-build/Dockerfile.playwright || exit 1
 ddev restart

--- a/commands/host/install-playwright
+++ b/commands/host/install-playwright
@@ -10,9 +10,11 @@ cd "$DDEV_APPROOT" || exit 1
 
 # Allow overriding the test directory location via .ddev/.env, e.g.:
 #   PLAYWRIGHT_TEST_DIR=tests/playwright
-set -a
-[ -f .ddev/.env ] && source .ddev/.env
-set +a
+# Sourced in a subshell so only PLAYWRIGHT_TEST_DIR escapes into this script —
+# anything else .ddev/.env sets (PATH, etc.) doesn't leak into the commands below.
+if [ -f .ddev/.env ]; then
+  PLAYWRIGHT_TEST_DIR=$(set -a && . .ddev/.env && set +a && echo "$PLAYWRIGHT_TEST_DIR")
+fi
 PLAYWRIGHT_TEST_DIR="${PLAYWRIGHT_TEST_DIR:-test/playwright}"
 
 mkdir -p "$PLAYWRIGHT_TEST_DIR"

--- a/commands/host/install-playwright
+++ b/commands/host/install-playwright
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
 #ddev-generated
 
-mkdir -p test/playwright
-if [ ! -f test/playwright/package.json ]; then
-  echo "No playwright installation exists at test/playwright."
+# Allow overriding the test directory location via .ddev/.env, e.g.:
+#   PLAYWRIGHT_TEST_DIR=tests/playwright
+set -a
+[ -f .ddev/.env ] && source .ddev/.env
+set +a
+PLAYWRIGHT_TEST_DIR="${PLAYWRIGHT_TEST_DIR:-test/playwright}"
+
+mkdir -p "$PLAYWRIGHT_TEST_DIR"
+if [ ! -f "$PLAYWRIGHT_TEST_DIR/package.json" ]; then
+  echo "No playwright installation exists at $PLAYWRIGHT_TEST_DIR."
   # https://github.com/microsoft/playwright/issues/11843
   echo "Playwright does not support a non-interactive setup and must be done manually."
   echo ""
   echo "Run the following to use npm:"
-  echo   ddev exec -d /var/www/html/test/playwright npm init playwright@latest
+  echo   ddev exec -d "/var/www/html/$PLAYWRIGHT_TEST_DIR" npm init playwright@latest
   echo ""
   echo "Run the following to use yarn instead:"
-  echo   ddev exec -d /var/www/html/test/playwright yarn create playwright
+  echo   ddev exec -d "/var/www/html/$PLAYWRIGHT_TEST_DIR" yarn create playwright
   echo ""
   echo "Answer "no" when it asks to install browsers and operating system dependencies,"
   echo "as those will be erased when ddev restarts."
@@ -23,12 +30,12 @@ if [ ! -f test/playwright/package.json ]; then
 fi
 
 # Validate that the package.json actually contains a Playwright dependency.
-if ! grep -qE '"@playwright/test"|"playwright"' test/playwright/package.json; then
-  echo "Error: test/playwright/package.json does not contain @playwright/test or playwright as a dependency."
+if ! grep -qE '"@playwright/test"|"playwright"' "$PLAYWRIGHT_TEST_DIR/package.json"; then
+  echo "Error: $PLAYWRIGHT_TEST_DIR/package.json does not contain @playwright/test or playwright as a dependency."
   echo ""
   echo "Please initialize Playwright first by running one of:"
-  echo "  ddev exec -d /var/www/html/test/playwright npm init playwright@latest"
-  echo "  ddev exec -d /var/www/html/test/playwright yarn create playwright"
+  echo "  ddev exec -d /var/www/html/$PLAYWRIGHT_TEST_DIR npm init playwright@latest"
+  echo "  ddev exec -d /var/www/html/$PLAYWRIGHT_TEST_DIR yarn create playwright"
   echo ""
   echo "When done, run: ddev install-playwright"
   exit 1

--- a/commands/web/playwright
+++ b/commands/web/playwright
@@ -1,7 +1,7 @@
 #!/bin/sh
 #ddev-generated
 
-cd test/playwright || exit 1
+cd "${PLAYWRIGHT_TEST_DIR:-test/playwright}" || exit 1
 
 if [ -f yarn.lock ]; then
   yarn && yarn playwright "$@"

--- a/config.playwright.yml
+++ b/config.playwright.yml
@@ -10,14 +10,18 @@ hooks:
     # why a mismatch here silently defeats its browser-caching trick.
     - exec-host: |
         if [[ -f .ddev/web-build/Dockerfile.playwright ]]; then
-          set -a
-          [[ -f .ddev/.env ]] && source .ddev/.env
-          set +a
+          # Sourced in a subshell so only PLAYWRIGHT_TEST_DIR escapes here —
+          # anything else .ddev/.env sets (PATH, etc.) doesn't leak into the
+          # cp/sed/rm calls below.
+          if [[ -f .ddev/.env ]]; then
+            PLAYWRIGHT_TEST_DIR=$(set -a && . .ddev/.env && set +a && echo "$PLAYWRIGHT_TEST_DIR")
+          fi
+          PLAYWRIGHT_TEST_DIR="${PLAYWRIGHT_TEST_DIR:-test/playwright}"
           cp .ddev/web-build/disabled.Dockerfile.playwright .ddev/web-build/Dockerfile.playwright
-          sed -i.bak "s|__PLAYWRIGHT_TEST_DIR__|${PLAYWRIGHT_TEST_DIR:-test/playwright}|g" .ddev/web-build/Dockerfile.playwright
+          sed -i.bak "s|__PLAYWRIGHT_TEST_DIR__|${PLAYWRIGHT_TEST_DIR}|g" .ddev/web-build/Dockerfile.playwright
           rm -f .ddev/web-build/Dockerfile.playwright.bak
           rm -rf .ddev/web-build/playwright
-          cp -r "${PLAYWRIGHT_TEST_DIR:-test/playwright}" .ddev/web-build/playwright
+          cp -r "${PLAYWRIGHT_TEST_DIR}" .ddev/web-build/playwright
         fi
   post-start:
     # Clean up the playwright directory copied for builds.

--- a/config.playwright.yml
+++ b/config.playwright.yml
@@ -8,8 +8,11 @@ hooks:
     - exec-host: |
         if [[ -f .ddev/web-build/Dockerfile.playwright ]]
         then
+          set -a
+          [[ -f .ddev/.env ]] && source .ddev/.env
+          set +a
           rm -rf .ddev/web-build/playwright
-          cp -r test/playwright .ddev/web-build/
+          cp -r "${PLAYWRIGHT_TEST_DIR:-test/playwright}" .ddev/web-build/playwright
         fi
   post-start:
     # Clean up the playwright directory copied for builds.
@@ -23,6 +26,9 @@ web_environment:
   # the writer). Keeps *.ddev.site trusted for Firefox without requiring
   # `ignoreHTTPSErrors: true`.
   - PLAYWRIGHT_FIREFOX_POLICIES_JSON=/tmp/playwright-firefox-policies.json
+  # Where Playwright tests live relative to the project root. Override by
+  # setting PLAYWRIGHT_TEST_DIR in .ddev/.env (e.g. PLAYWRIGHT_TEST_DIR=tests/playwright).
+  - PLAYWRIGHT_TEST_DIR=${PLAYWRIGHT_TEST_DIR:-test/playwright}
 # We add the sleep so this doesn't error out when not using playwright.
 web_extra_daemons:
   - name: "kasmvnc"

--- a/config.playwright.yml
+++ b/config.playwright.yml
@@ -1,16 +1,21 @@
 #ddev-generated
 hooks:
   pre-start:
-    # If Playwright is enabled, make sure we get any changes.
+    # If Playwright is enabled, make sure we get any changes, and bake in the
+    # configured PLAYWRIGHT_TEST_DIR value. A plain Dockerfile has no way to
+    # read a host env var at build time, so we substitute the real value into
+    # Dockerfile.playwright here, on the host, before the build ever sees it.
+    # That value has to land at the *exact* runtime path — see the
+    # __PLAYWRIGHT_TEST_DIR__ comment in disabled.Dockerfile.playwright for
+    # why a mismatch here silently defeats its browser-caching trick.
     - exec-host: |
-        ([[ -f .ddev/web-build/Dockerfile.playwright ]] && \
-          cp .ddev/web-build/disabled.Dockerfile.playwright .ddev/web-build/Dockerfile.playwright) || true
-    - exec-host: |
-        if [[ -f .ddev/web-build/Dockerfile.playwright ]]
-        then
+        if [[ -f .ddev/web-build/Dockerfile.playwright ]]; then
           set -a
           [[ -f .ddev/.env ]] && source .ddev/.env
           set +a
+          cp .ddev/web-build/disabled.Dockerfile.playwright .ddev/web-build/Dockerfile.playwright
+          sed -i.bak "s|__PLAYWRIGHT_TEST_DIR__|${PLAYWRIGHT_TEST_DIR:-test/playwright}|g" .ddev/web-build/Dockerfile.playwright
+          rm -f .ddev/web-build/Dockerfile.playwright.bak
           rm -rf .ddev/web-build/playwright
           cp -r "${PLAYWRIGHT_TEST_DIR:-test/playwright}" .ddev/web-build/playwright
         fi

--- a/install.yaml
+++ b/install.yaml
@@ -29,7 +29,7 @@ post_install_actions:
       printf '\n# This file is optionally copied to enable playwright from\n# disabled.Dockerfile.playwright.\nDockerfile.playwright\n' >> "$GITIGNORE"
     fi
     if ! grep -qx "playwright" "$GITIGNORE"; then
-      printf '\n# This directory is always copied from /test/playwright.\nplaywright\n' >> "$GITIGNORE"
+      printf '\n# This directory is always copied from PLAYWRIGHT_TEST_DIR (default test/playwright).\nplaywright\n' >> "$GITIGNORE"
     fi
 
 removal_actions:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -102,7 +102,7 @@ verify_run_playwright() {
   verify_run_playwright
 }
 
-@test "install from directory with npm and custom PLAYWRIGHT_TEST_DIR" {
+@test "install from directory with npm and custom PLAYWRIGHT_TEST_DIR (tests/playwright)" {
   get_addon tests
   echo "PLAYWRIGHT_TEST_DIR=tests/playwright" > .ddev/.env
   cp -av "$DIR"/tests/testdata/npm-playwright tests/playwright

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -57,18 +57,19 @@ get_addon() {
   assert [ -x .ddev/web-build/install-task.sh ]
   assert [ -f .ddev/web-build/kasmvnc.yaml ]
   assert [ -f .ddev/web-build/xstartup ]
-  mkdir test
+  mkdir "${1:-test}"
 }
 
 verify_run_playwright() {
+  local playwright_dir="${1:-test/playwright}"
   cp -av "$DIR"/tests/testdata/web/* web/
   assert [ -f web/index.php ]
   ddev install-playwright
 
   ddev exec -- which task
 
-  mkdir -p test/playwright/tests
-  cp "$DIR"/tests/testdata/phpinfo.spec.ts test/playwright/tests/phpinfo.spec.ts
+  mkdir -p "${playwright_dir}/tests"
+  cp "$DIR"/tests/testdata/phpinfo.spec.ts "${playwright_dir}/tests/phpinfo.spec.ts"
   health_checks
 
   # Verify kasmvnc is listening.
@@ -99,6 +100,14 @@ verify_run_playwright() {
   get_addon
   cp -av "$DIR"/tests/testdata/yarn-playwright test/playwright
   verify_run_playwright
+}
+
+@test "install from directory with npm and custom PLAYWRIGHT_TEST_DIR" {
+  get_addon tests
+  echo "PLAYWRIGHT_TEST_DIR=tests/playwright" > .ddev/.env
+  cp -av "$DIR"/tests/testdata/npm-playwright tests/playwright
+  ddev exec -d /var/www/html/tests/playwright npm ci
+  verify_run_playwright tests/playwright
 }
 
 @test "install requires a playwright installation" {

--- a/web-build/disabled.Dockerfile.playwright
+++ b/web-build/disabled.Dockerfile.playwright
@@ -11,14 +11,21 @@ RUN apt-get update
 # start is run. In general, edit this file instead.
 #
 # We want to install whatever browsers are used by the currently locked version
-# of playwright in test/playwright. What this does is:
+# of playwright in PLAYWRIGHT_TEST_DIR. What this does is:
 #
-# 1. Creates a copy of the playwright directory in the image. We need this
-#    because Playwright keeps a hidden .links/<hash> file with the path of
-#    what browsers are installed by what apps. Without it, Playwright will re-
-#    download browsers even though they are in the directory. As the Docker
-#    context is the web-build directory, we have a pre-start hook in
-#    config.yaml that copies in the current test files.
+# 1. Creates a copy of the playwright directory in the image, at the *same*
+#    path PLAYWRIGHT_TEST_DIR resolves to at runtime (/var/www/html/__PLAYWRIGHT_TEST_DIR__
+#    below — substituted with the real value on the host before the build
+#    ever sees this file, since a plain Dockerfile has no way to read a host
+#    env var; see the pre-start hook in config.playwright.yml that does the
+#    substitution). The path has to match exactly, because Playwright keeps a
+#    hidden .links/<hash> file keyed on the install path to know what browsers
+#    are installed by what apps — install at the wrong path here and
+#    Playwright won't recognize the real runtime path as already having
+#    browsers, and will re-download them there even though they're already in
+#    the image. As the Docker context is the web-build directory, we have a
+#    pre-start hook in config.playwright.yml that copies in the current test
+#    files.
 # 2. $username doesn't work in --mount... lines as it's a shell variable set by
 #    ddev. Instead, we mount the .cache cache into /ms-playwright-cache, and
 #    symlink it in. We merge any existing ~/.cache content into the mount first
@@ -38,14 +45,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   --mount=type=cache,target=/ms-playwright-cache,sharing=locked \
   --mount=type=bind,source=./playwright,target=/playwright \
-  sudo -u $username mkdir -p /var/www/html/test \
-  && cp -a /playwright /var/www/html/test \
-  && chown -R $username:$username /var/www/html/test/playwright \
+  sudo -u $username mkdir -p /var/www/html/__PLAYWRIGHT_TEST_DIR__ \
+  && cp -a /playwright/. /var/www/html/__PLAYWRIGHT_TEST_DIR__ \
+  && chown -R $username:$username /var/www/html/__PLAYWRIGHT_TEST_DIR__ \
   && chown -R $username:$username /ms-playwright-cache \
   && cp -an /home/$username/.cache/* /ms-playwright-cache/ 2>/dev/null; \
   rm -rf /home/$username/.cache \
   && sudo -u $username ln -s /ms-playwright-cache /home/$username/.cache \
-  && cd /var/www/html/test/playwright \
+  && cd /var/www/html/__PLAYWRIGHT_TEST_DIR__ \
   && if [ -f yarn.lock ]; then \
        export JS_PKG_MANAGER=yarn; \
        corepack enable; \
@@ -56,7 +63,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
      fi \
   && sudo -u $username $JS_PKG_MANAGER playwright install-deps \
   && sudo -u $username PLAYWRIGHT_SKIP_BROWSER_GC=1 $JS_PKG_MANAGER playwright install \
-  && rm -rf /var/www/html/test/playwright \
+  && rm -rf /var/www/html/__PLAYWRIGHT_TEST_DIR__ \
   && rm /home/$username/.cache \
   && sudo -u $username mkdir -p /home/$username/.cache \
   && sudo -u $username cp -a /ms-playwright-cache/* /home/$username/.cache/


### PR DESCRIPTION
## Summary
- Adds a `PLAYWRIGHT_TEST_DIR` variable (default `test/playwright`) so projects can put Playwright tests under a different path, e.g. `tests/playwright`, without patching the addon.
- Settable via `.ddev/.env`, which is the one place DDEV lets both host-side scripts (the `pre-start` hook, `install-playwright`) and the web container (`web_environment`) read the same value.
- `config.playwright.yml`'s `pre-start` hook now sources `.ddev/.env` directly, since host-side hooks aren't auto-loaded from it.
- Backward compatible: no `.ddev/.env` entry means everything behaves exactly as before.

## Related issue(s)
Closes #122

## How to test
```bash
echo "PLAYWRIGHT_TEST_DIR=tests/playwright" >> .ddev/.env
ddev restart
mkdir -p tests/playwright
ddev exec -d /var/www/html/tests/playwright npm init playwright@latest
ddev install-playwright
ddev playwright test
```
Also added a bats case, `install from directory with npm and custom PLAYWRIGHT_TEST_DIR`, covering this end-to-end.

## Additional notes
Similar to the `PLAYWRIGHT_TEST_DIR` support in julienloizelet/ddev-playwright, adapted for this addon's architecture (Playwright runs in the `web` container rather than a separate service, and the path is also needed by host-side scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)