### PR TITLE
ci: automerge all renovate updates except action digest moves

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -34,7 +34,7 @@ jobs:
     name: Validate commit messages
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: ddev/github-action-add-on-test@b6002da3c9c8168ce1f2f77ce009e5569597950e # v2
+    - uses: ddev/github-action-add-on-test@b6002da3c9c8168ce1f2f77ce009e5569597950e # v2.4.4
       with:
         ddev_version: ${{ matrix.ddev_version }}
         addon_repository: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "customManagers": [
     {
@@ -19,7 +19,9 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "description": "Never automerge a digest-only update: that is an existing action tag being repointed at a new commit, which needs a human to look at it.",
+      "matchDepTypes": ["action"],
+      "matchUpdateTypes": ["digest"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
- Every dependency type keeps the 3 day cooldown (minimumReleaseAge).
- Drop the blanket automerge:false on the github-actions manager so action version bumps automerge like everything else.
- Add a narrow exception: digest-only updates (an existing tag repointed at a new commit) are never automerged and need a human review.
- Switch to helpers:pinGitHubActionDigestsToSemver so actions stay pinned to a hash and the trailing version comment is the full semver tag (v6.0.3) rather than the major alias (v6).
- Rewrite the existing comments in the workflows to the full tags that the currently pinned SHAs correspond to.


Claude-Session: https://claude.ai/code/session_011DEFVrfTZ2S7FNjHNnHYjM