### PR TITLE
ci: allow perf as a conventional commit type

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -26,6 +26,7 @@ jobs:
             docs
             feat
             fix
+            perf
             refactor
             revert
             test
@@ -39,4 +40,4 @@ jobs:
           fetch-depth: 0
       - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2
         with:
-          allowed-commit-types: chore,ci,docs,feat,fix,refactor,revert,test
+          allowed-commit-types: chore,ci,docs,feat,fix,perf,refactor,revert,test


### PR DESCRIPTION
Both validators rejected `perf`, so a genuine performance change had to be mislabelled as fix or refactor. It came up on #136, where the PR title check failed with `Unknown release type "perf"` while the change was exactly what perf describes.

Added to both lists, which had drifted apart in intent anyway: the PR title check and the commit message check are meant to enforce the same vocabulary.

No release-please change needed. perf is already one of its default changelog sections ("Performance Improvements") and bumps a patch, so these commits show up in the changelog rather than being silently dropped the way a type outside its defaults would be.


Claude-Session: https://claude.ai/code/session_01WCuvedjPidwggD7d9pjfRk