### PR TITLE
fix: bind the report server where DDEV's router can reach it

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,31 @@ ddev-playwright: the address Playwright prints below is the in-container one.
 ```
 
 Playwright's own line is accurate, but describes the address *inside* the
-container. DDEV's router publishes that as port 9324 on your host — 9323 is
-left alone so it does not conflict with a Playwright report served directly on
-the host.
+container. The router publishes it on the host at the port in the table above.
 
-If the report URL returns `502 Bad Gateway`, the report server is bound to an
-address the router cannot reach. The router connects to the web container over
-the Docker network, so `--host=127.0.0.1` (or `localhost`) binds to the
-container's own loopback interface and shuts the router out. Drop the flag.
-Binding `0.0.0.0`, which this command does for you, does not expose the report
-to your network: container port 9323 is not published, so the router is still
-the only way in.
+### Reaching any server you start in the container
+
+Two rules govern every server started inside the web container, not just the
+report:
+
+1. **Bind `0.0.0.0`, never `localhost`.** The router connects over the Docker
+   network, so a server on the container's loopback interface is invisible to
+   it and the routed URL answers `502 Bad Gateway`. Binding `0.0.0.0` does not
+   expose anything to your network — the container port is not published, so
+   the router is still the only way in.
+2. **Use a port in `web_extra_exposed_ports`.** Anything else is not routed at
+   all, whatever it is bound to.
+
+`ddev playwright show-report` already satisfies both, which is why it needs no
+flags. Playwright's other servers default to `localhost` and need saying
+explicitly — both of these come out at `https://<PROJECT>.ddev.site:9324`:
+
+```bash
+ddev playwright test --ui --ui-host=0.0.0.0 --ui-port=9323
+ddev playwright show-trace --host=0.0.0.0 --port=9323
+```
+
+Run only one at a time; they share the single routed port.
 
 ## SQLite tmpfs mount
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,9 @@ ddev-playwright: the address Playwright prints below is the in-container one.
 Playwright's own line is accurate, but describes the address *inside* the
 container. The router publishes it on the host at the port in the table above.
 
-### Reaching any server you start in the container
+### Accessing other Playwright HTTP services beyond show-report
 
-Two rules govern every server started inside the web container, not just the
-report:
+When running commands like `show-trace`, always:
 
 1. **Bind `0.0.0.0`, never `localhost`.** The router connects over the Docker
    network, so a server on the container's loopback interface is invisible to

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ _Example test validating phpinfo(), slowed down for the demo._
 
 * [What is ddev-playwright?](#what-is-ddev-playwright)
 * [Getting started](#getting-started)
+* [Viewing test reports](#viewing-test-reports)
 * [SQLite tmpfs mount](#sqlite-tmpfs-mount)
 * [What the browser install sees](#what-the-browser-install-sees)
 * [Contributing](#contributing)
@@ -65,11 +66,10 @@ ddev playwright test
 ddev playwright test --headed
 # To generate playwright code by browsing.
 ddev playwright codegen
-# To view the HTML test report.
-# Bind to the loopback interface inside the container, which is sufficient for
-# DDEV routing and keeps the report server more constrained.
-ddev playwright show-report --host=127.0.0.1
-# The report is then accessible at https://<PROJECT>.ddev.site:9324
+# To view the HTML test report. The command prints the URL to open; no --host
+# flag is needed.
+ddev playwright show-report
+# The report is accessible at https://<PROJECT>.ddev.site:9324
 ```
 
 The following services are exposed with this addon:
@@ -78,6 +78,31 @@ The following services are exposed with this addon:
 |-------------------------|-----------------------------------|--------------------------------------------------------------------------------------------|
 | KasmVNC                 | https://\<PROJECT>.ddev.site:8444 | Username is your local username. Password is `secret`.                                     |
 | Playwright Test Reports | https://\<PROJECT>.ddev.site:9324 | This port is changed from the default to not conflict with running Playwright on the host. |
+
+## Viewing test reports
+
+`ddev playwright show-report` needs no flags. It serves the report from the
+web container and prints the URL to open:
+
+```
+ddev-playwright: view the report at https://<PROJECT>.ddev.site:9324
+ddev-playwright: the address Playwright prints below is the in-container one.
+
+  Serving HTML report at http://0.0.0.0:9323. Press Ctrl+C to quit.
+```
+
+Playwright's own line is accurate, but describes the address *inside* the
+container. DDEV's router publishes that as port 9324 on your host — 9323 is
+left alone so it does not conflict with a Playwright report served directly on
+the host.
+
+If the report URL returns `502 Bad Gateway`, the report server is bound to an
+address the router cannot reach. The router connects to the web container over
+the Docker network, so `--host=127.0.0.1` (or `localhost`) binds to the
+container's own loopback interface and shuts the router out. Drop the flag.
+Binding `0.0.0.0`, which this command does for you, does not expose the report
+to your network: container port 9323 is not published, so the router is still
+the only way in.
 
 ## SQLite tmpfs mount
 

--- a/commands/web/playwright
+++ b/commands/web/playwright
@@ -3,96 +3,103 @@
 
 cd "${PLAYWRIGHT_TEST_DIR:-test/playwright}" || exit 1
 
-# The container port config.playwright.yml maps for the HTML report, and the
-# host-side ports the router publishes for it. Keep all three in sync with
+# The container port config.playwright.yml routes the HTML report through, and
+# the host-side ports the router publishes for it. Keep all three in sync with
 # web_extra_exposed_ports there.
 REPORT_CONTAINER_PORT=9323
 REPORT_HTTPS_PORT=9324
 REPORT_HTTP_PORT=8323
 
-# The URL a browser on the host uses to reach the report server. DDEV_HOSTNAME
-# is a comma-separated list when a project has additional hostnames, so take
-# the first. Deriving the scheme from DDEV_PRIMARY_URL keeps this correct for
-# projects configured http-only, where the router publishes only the http port.
+# The URL a browser on the host uses to reach the report server.
+# DDEV_PRIMARY_URL_WITHOUT_PORT is the project's primary hostname with the
+# scheme attached and any router port already stripped, which is exactly the
+# base needed here -- deriving it from DDEV_HOSTNAME instead would mean owning
+# DDEV's rules for hostname ordering. Older DDEV releases set only
+# DDEV_PRIMARY_URL, so strip the port here for those.
 report_url() {
-  case "${DDEV_PRIMARY_URL:-https://}" in
-    http://*) printf 'http://%s:%s' "${DDEV_HOSTNAME%%,*}" "$REPORT_HTTP_PORT" ;;
-    *) printf 'https://%s:%s' "${DDEV_HOSTNAME%%,*}" "$REPORT_HTTPS_PORT" ;;
+  base="${DDEV_PRIMARY_URL_WITHOUT_PORT:-${DDEV_PRIMARY_URL%:[0-9]*}}"
+  case "$base" in
+    http://*) printf '%s:%s' "$base" "$REPORT_HTTP_PORT" ;;
+    *) printf '%s:%s' "$base" "$REPORT_HTTPS_PORT" ;;
   esac
 }
 
 # `show-report` starts a web server inside the web container, and DDEV's router
 # reaches that server over the Docker network -- never over the container's own
-# loopback interface. A report server bound to 127.0.0.1 is therefore invisible
-# to the router, which answers the routed URL with a 502 Bad Gateway. Binding
-# 0.0.0.0 does not expose the report to the host network either: the container
-# port is not published, so the router remains the only way in.
+# loopback interface. A report server bound to Playwright's default of
+# localhost is therefore invisible to the router, which answers the routed URL
+# with a 502 Bad Gateway. Binding 0.0.0.0 does not expose the report to the
+# host network either: the container port is not published, so the router
+# remains the only way in.
 #
-# Playwright then prints "Serving HTML report at http://0.0.0.0:9323", which is
-# true inside the container and useless from a browser on the host, so print
-# the routed URL immediately before handing over.
-report_advice() {
-  case "$1" in
-    127.0.0.1 | localhost | ::1)
-      echo "ddev-playwright: --host=$1 binds the report server to the container's" >&2
-      echo "loopback interface, where DDEV's router cannot reach it. Drop the flag --" >&2
-      echo "ddev playwright show-report binds 0.0.0.0 on its own." >&2
-      ;;
-    *)
-      if [ "$2" != "$REPORT_CONTAINER_PORT" ]; then
-        echo "ddev-playwright: the router only forwards to container port ${REPORT_CONTAINER_PORT}, so a" >&2
-        echo "report served on port ${2:-something else} is not reachable from the host." >&2
-      else
-        echo "ddev-playwright: view the report at $(report_url)"
-        echo "ddev-playwright: the address Playwright prints below is the in-container one."
-      fi
-      ;;
-  esac
-}
-
-# Both defaults match what the router expects, so a plain
-# `ddev playwright show-report` works with no flags at all. An explicit --host
-# or --port, right or wrong, is left alone: report_advice says why it will not
-# reach the browser rather than silently overriding it.
-is_show_report=false
-report_host=
-report_port=
+# This has to happen here rather than in configuration. show-report reads
+# neither playwright.config.ts nor PLAYWRIGHT_HTML_HOST -- both only reach the
+# html reporter's own auto-open path -- so the CLI flag is the only lever.
 if [ "$1" = "show-report" ]; then
-  is_show_report=true
-  report_host=0.0.0.0
-  report_port="$REPORT_CONTAINER_PORT"
-  host_given=false
-  # Playwright accepts both --host=VALUE and --host VALUE, so track the case
-  # where the value is the next argument rather than part of this one.
+  # Prepended, not appended: Playwright's last --host wins, so a flag the user
+  # typed still overrides this default in either --host=VALUE or --host VALUE
+  # form, and a trailing flag never swallows ours as its missing value.
+  shift
+  set -- show-report --host=0.0.0.0 "$@"
+fi
+
+# Say where the report will actually be reachable. Playwright prints
+# "Serving HTML report at http://0.0.0.0:9323", which is true inside the
+# container and useless from a browser on the host.
+#
+# The scan runs over the final argument list, so what it finds is the host and
+# port Playwright will settle on, default included.
+report_advice() {
+  [ "$1" = "show-report" ] || return 0
+
+  advice_host=
+  advice_port="$REPORT_CONTAINER_PORT"
   pending=
   for arg in "$@"; do
     case "$pending" in
-      host) report_host="$arg" pending= ; continue ;;
-      port) report_port="$arg" pending= ; continue ;;
+      host) advice_host="$arg" pending= ; continue ;;
+      port) advice_port="$arg" pending= ; continue ;;
     esac
     case "$arg" in
-      --host=*) report_host="${arg#--host=}" host_given=true ;;
-      --port=*) report_port="${arg#--port=}" ;;
-      --host) pending=host host_given=true ;;
+      --host=*) advice_host="${arg#--host=}" ;;
+      --port=*) advice_port="${arg#--port=}" ;;
+      --host) pending=host ;;
       --port) pending=port ;;
     esac
   done
-  if [ "$host_given" = false ]; then
-    set -- "$@" --host="$report_host"
-  fi
-fi
 
-run_playwright() {
-  if [ "$is_show_report" = true ]; then
-    report_advice "$report_host" "$report_port"
+  # A trailing --host or --port with no value. Playwright rejects that command
+  # line, so promise nothing about a server that is not going to start.
+  [ -z "$pending" ] || return 0
+
+  case "$advice_host" in
+    127.0.0.1 | localhost | ::1)
+      echo "ddev-playwright: --host=${advice_host} binds the report server to the container's" >&2
+      echo "loopback interface, where DDEV's router cannot reach it. Drop the flag --" >&2
+      echo "ddev playwright show-report binds 0.0.0.0 on its own." >&2
+      return 0
+      ;;
+  esac
+
+  if [ "$advice_port" != "$REPORT_CONTAINER_PORT" ]; then
+    echo "ddev-playwright: the router only forwards to container port ${REPORT_CONTAINER_PORT}, so a" >&2
+    echo "report served on any other port is not reachable from the host." >&2
+    return 0
   fi
-  exec "$@"
+
+  echo "ddev-playwright: view the report at $(report_url)"
+  echo "ddev-playwright: the address Playwright prints below is the in-container one."
 }
 
+# The advice prints after the install so it lands directly above Playwright's
+# own "Serving HTML report at ..." line, rather than scrolling away under the
+# package manager's output.
 if [ -f yarn.lock ]; then
   yarn || exit
-  run_playwright yarn playwright "$@"
+  report_advice "$@"
+  exec yarn playwright "$@"
 else
   npm ci || exit
-  run_playwright npx playwright "$@"
+  report_advice "$@"
+  exec npx playwright "$@"
 fi

--- a/commands/web/playwright
+++ b/commands/web/playwright
@@ -3,8 +3,96 @@
 
 cd "${PLAYWRIGHT_TEST_DIR:-test/playwright}" || exit 1
 
+# The container port config.playwright.yml maps for the HTML report, and the
+# host-side ports the router publishes for it. Keep all three in sync with
+# web_extra_exposed_ports there.
+REPORT_CONTAINER_PORT=9323
+REPORT_HTTPS_PORT=9324
+REPORT_HTTP_PORT=8323
+
+# The URL a browser on the host uses to reach the report server. DDEV_HOSTNAME
+# is a comma-separated list when a project has additional hostnames, so take
+# the first. Deriving the scheme from DDEV_PRIMARY_URL keeps this correct for
+# projects configured http-only, where the router publishes only the http port.
+report_url() {
+  case "${DDEV_PRIMARY_URL:-https://}" in
+    http://*) printf 'http://%s:%s' "${DDEV_HOSTNAME%%,*}" "$REPORT_HTTP_PORT" ;;
+    *) printf 'https://%s:%s' "${DDEV_HOSTNAME%%,*}" "$REPORT_HTTPS_PORT" ;;
+  esac
+}
+
+# `show-report` starts a web server inside the web container, and DDEV's router
+# reaches that server over the Docker network -- never over the container's own
+# loopback interface. A report server bound to 127.0.0.1 is therefore invisible
+# to the router, which answers the routed URL with a 502 Bad Gateway. Binding
+# 0.0.0.0 does not expose the report to the host network either: the container
+# port is not published, so the router remains the only way in.
+#
+# Playwright then prints "Serving HTML report at http://0.0.0.0:9323", which is
+# true inside the container and useless from a browser on the host, so print
+# the routed URL immediately before handing over.
+report_advice() {
+  case "$1" in
+    127.0.0.1 | localhost | ::1)
+      echo "ddev-playwright: --host=$1 binds the report server to the container's" >&2
+      echo "loopback interface, where DDEV's router cannot reach it. Drop the flag --" >&2
+      echo "ddev playwright show-report binds 0.0.0.0 on its own." >&2
+      ;;
+    *)
+      if [ "$2" != "$REPORT_CONTAINER_PORT" ]; then
+        echo "ddev-playwright: the router only forwards to container port ${REPORT_CONTAINER_PORT}, so a" >&2
+        echo "report served on port ${2:-something else} is not reachable from the host." >&2
+      else
+        echo "ddev-playwright: view the report at $(report_url)"
+        echo "ddev-playwright: the address Playwright prints below is the in-container one."
+      fi
+      ;;
+  esac
+}
+
+# Both defaults match what the router expects, so a plain
+# `ddev playwright show-report` works with no flags at all. An explicit --host
+# or --port, right or wrong, is left alone: report_advice says why it will not
+# reach the browser rather than silently overriding it.
+is_show_report=false
+report_host=
+report_port=
+if [ "$1" = "show-report" ]; then
+  is_show_report=true
+  report_host=0.0.0.0
+  report_port="$REPORT_CONTAINER_PORT"
+  host_given=false
+  # Playwright accepts both --host=VALUE and --host VALUE, so track the case
+  # where the value is the next argument rather than part of this one.
+  pending=
+  for arg in "$@"; do
+    case "$pending" in
+      host) report_host="$arg" pending= ; continue ;;
+      port) report_port="$arg" pending= ; continue ;;
+    esac
+    case "$arg" in
+      --host=*) report_host="${arg#--host=}" host_given=true ;;
+      --port=*) report_port="${arg#--port=}" ;;
+      --host) pending=host host_given=true ;;
+      --port) pending=port ;;
+    esac
+  done
+  if [ "$host_given" = false ]; then
+    set -- "$@" --host="$report_host"
+  fi
+fi
+
+run_playwright() {
+  if [ "$is_show_report" = true ]; then
+    report_advice "$report_host" "$report_port"
+  fi
+  exec "$@"
+}
+
 if [ -f yarn.lock ]; then
-  yarn && yarn playwright "$@"
+  yarn || exit
+  run_playwright yarn playwright "$@"
 else
-  npm ci && npx playwright "$@"
+  npm ci || exit
+  run_playwright npx playwright "$@"
 fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -145,25 +145,28 @@ verify_run_playwright() {
   verify_show_report
 }
 
-# The HTML report is only reachable through DDEV's router, and the router
-# connects to the web container over the Docker network -- never over the
-# container's loopback interface. A report server bound to 127.0.0.1 is
-# therefore invisible to it, and the routed URL answers 502 Bad Gateway, which
-# is what https://github.com/Lullabot/ddev-playwright/issues/103 reported after
-# the README started recommending --host=127.0.0.1.
-#
-# So this asserts the routed URL, not the in-container one: a test that curled
-# the container port directly would pass with either binding and catch nothing.
+# Assert through the routed URL, not the container port: a request straight to
+# 9323 succeeds whichever interface the report server bound, so it would not
+# catch https://github.com/Lullabot/ddev-playwright/issues/103. See the comment
+# above report_advice in commands/web/playwright for why the binding matters.
 verify_show_report() {
   local log="${TESTDIR}/show-report.log"
+  local url="https://${PROJNAME}.ddev.site:9324"
 
   ddev playwright show-report >"${log}" 2>&1 &
   local report_pid=$!
 
   local code=""
-  local attempt
-  for attempt in $(seq 1 30); do
-    code=$(curl -sk -o /dev/null -w '%{http_code}' "https://${PROJNAME}.ddev.site:9324/" || true)
+  # `ddev playwright show-report` reinstalls dependencies before it starts the
+  # server -- `npm ci` deletes and rebuilds node_modules every time, which is
+  # pure waste for a subcommand that only serves a directory. Until that is
+  # fixed this budget has to cover a full install on a loaded runner, not just
+  # the few seconds the report server itself needs.
+  #
+  # --max-time keeps that budget honest: without it a router that accepts and
+  # then hangs would stretch each attempt out to curl's own default timeout.
+  for _ in $(seq 1 60); do
+    code=$(curl -sk --max-time 5 -o /dev/null -w '%{http_code}' "${url}/" || true)
     if [ "${code}" = "200" ]; then
       break
     fi
@@ -174,7 +177,12 @@ verify_show_report() {
   wait "${report_pid}" >/dev/null 2>&1 || true
   # Killing the host-side `ddev` leaves the report server running inside the
   # container, holding port 9323 against the next test in this project.
-  ddev exec -- pkill -f 'playwright.*show-report' >/dev/null 2>&1 || true
+  #
+  # `ddev exec` runs this through a shell, so the wrapper's own command line
+  # contains the pattern and pkill -f would match -- and signal -- its own
+  # parent. The bracket makes the pattern match the report server without
+  # matching the literal text of the pkill invocation.
+  ddev exec -- pkill -f '[p]laywright.*show-report' >/dev/null 2>&1 || true
 
   echo "# show-report log:" >&3
   sed 's/^/# /' "${log}" >&3
@@ -182,7 +190,7 @@ verify_show_report() {
   # The URL the user is meant to open, printed above Playwright's own
   # "Serving HTML report at http://0.0.0.0:9323" line.
   run cat "${log}"
-  assert_output --partial "view the report at https://${PROJNAME}.ddev.site:9324"
+  assert_output --partial "view the report at ${url}"
 
   assert_equal "${code}" "200"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -137,8 +137,54 @@ verify_run_playwright() {
 
   assert_invariant_layers_precede_browser_install
 
-  # Verify we can run an example test.
-  ddev playwright test --reporter=line
+  # Verify we can run an example test. The reporters come from
+  # playwright.config.ts (line + html); the html one leaves behind a report for
+  # verify_show_report to serve.
+  ddev playwright test
+
+  verify_show_report
+}
+
+# The HTML report is only reachable through DDEV's router, and the router
+# connects to the web container over the Docker network -- never over the
+# container's loopback interface. A report server bound to 127.0.0.1 is
+# therefore invisible to it, and the routed URL answers 502 Bad Gateway, which
+# is what https://github.com/Lullabot/ddev-playwright/issues/103 reported after
+# the README started recommending --host=127.0.0.1.
+#
+# So this asserts the routed URL, not the in-container one: a test that curled
+# the container port directly would pass with either binding and catch nothing.
+verify_show_report() {
+  local log="${TESTDIR}/show-report.log"
+
+  ddev playwright show-report >"${log}" 2>&1 &
+  local report_pid=$!
+
+  local code=""
+  local attempt
+  for attempt in $(seq 1 30); do
+    code=$(curl -sk -o /dev/null -w '%{http_code}' "https://${PROJNAME}.ddev.site:9324/" || true)
+    if [ "${code}" = "200" ]; then
+      break
+    fi
+    sleep 2
+  done
+
+  kill "${report_pid}" >/dev/null 2>&1 || true
+  wait "${report_pid}" >/dev/null 2>&1 || true
+  # Killing the host-side `ddev` leaves the report server running inside the
+  # container, holding port 9323 against the next test in this project.
+  ddev exec -- pkill -f 'playwright.*show-report' >/dev/null 2>&1 || true
+
+  echo "# show-report log:" >&3
+  sed 's/^/# /' "${log}" >&3
+
+  # The URL the user is meant to open, printed above Playwright's own
+  # "Serving HTML report at http://0.0.0.0:9323" line.
+  run cat "${log}"
+  assert_output --partial "view the report at https://${PROJNAME}.ddev.site:9324"
+
+  assert_equal "${code}" "200"
 }
 
 # Guard the Dockerfile layer ordering.

--- a/tests/testdata/npm-playwright/playwright.config.ts
+++ b/tests/testdata/npm-playwright/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* The line reporter keeps the bats output readable; the html reporter gives
+   * `ddev playwright show-report` something to serve. open: 'never' stops a
+   * failing run from starting a report server the suite would then wait on. */
+  reporter: [['line'], ['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     // Proves the addon's mkcert trust setup works across all three browsers.

--- a/tests/testdata/yarn-playwright/playwright.config.ts
+++ b/tests/testdata/yarn-playwright/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* The line reporter keeps the bats output readable; the html reporter gives
+   * `ddev playwright show-report` something to serve. open: 'never' stops a
+   * failing run from starting a report server the suite would then wait on. */
+  reporter: [['line'], ['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     // Proves the addon's mkcert trust setup works across all three browsers.


### PR DESCRIPTION
`ddev playwright show-report --host=127.0.0.1`, which the README has recommended since #93, serves the HTML report on the web container's own loopback interface. DDEV's router connects to that container over the Docker network instead, so it never reaches the report server and answers the routed URL with a 502 Bad Gateway -- the symptom reported in #103.

show-report now defaults to --host=0.0.0.0, so it needs no flag at all. That does not expose the report to the host network either: container port 9323 is not published, leaving the router as the only way in. An explicit --host or --port is still honoured, with a note saying why it will not be reachable, rather than silently overridden.

Playwright's own "Serving HTML report at http://0.0.0.0:9323" line is accurate but describes the in-container address, and #103 found that confusing next to the 9324 in `ddev describe`. Print the routed URL immediately above it and label the line below for what it is.

The new test asserts against the routed URL rather than the container port, since a request straight to 9323 succeeds under either binding and would catch nothing. The testdata configs gain the html reporter, with open: 'never' so a failing run cannot start a report server the suite would then wait on.

Refs #103


Claude-Session: https://claude.ai/code/session_01YZyXTWUBXi2LAkbf1kaC2D